### PR TITLE
fix DSO linking error in fedora and arch linux

### DIFF
--- a/sensors-applet/Makefile.am
+++ b/sensors-applet/Makefile.am
@@ -41,7 +41,9 @@ mate_sensors_applet_SOURCES = main.c \
 		sensors-applet-plugins.h \
 		sensors-applet-settings.c \
 		sensors-applet-settings.h \
-		$(libmatenotify_SRC) 
+		$(libmatenotify_SRC)
+
+mate_sensors_applet_LDADD = -ldl
 
 # install headers for plugins to use
 INST_H_FILES = sensors-applet-plugin.h sensors-applet-sensor.h


### PR DESCRIPTION
to avoid this error

/usr/bin/ld: sensors-applet-plugins.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: note: 'dlclose@@GLIBC_2.2.5' is defined in DSO /lib64/libdl.so.2 so try adding it to the linker command line
/lib64/libdl.so.2: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
