### PR TITLE
Fix non-portable "==" operator for test(1)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AC_ARG_WITH(aticonfig,
 	with_aticonfig="check"
 ])
 
-if test "x$with_aticonfig" == "xcheck"; then
+if test "x$with_aticonfig" = "xcheck"; then
 	AC_CHECK_PROG(ATICONFIG_EXE, ["$aticonfig_exe"], yes, no)
         if test "x$ATICONFIG_EXE" = "xno"; then
 		with_aticonfig="no"


### PR DESCRIPTION
"==" operator of test(1) is only implemented by bash and some versions of the ksh.