### PR TITLE
gtk3: Replace gtk_widget_size_request with gtk_widget_get_preferred_size

### DIFF
--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -49,7 +49,10 @@
                                 * sensors_applet->size to ensure a
                                 * real value is stored */
 #define COLUMN_SPACING 2
-#define ROW_SPACING 0
+#define ROW_SPACING 1
+#if GTK_CHECK_VERSION (3, 0, 0)
+#define gtk_widget_size_request(X,Y) gtk_widget_get_preferred_size(X,Y,NULL)
+#endif
 
 /* callbacks for panel menu */
 static void prefs_cb(GtkAction *action,
@@ -508,14 +511,8 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
         case DISPLAY_VALUE:
                 gtk_widget_size_request(GTK_WIDGET(first_sensor->value),
                                         &req);
-/* FIXME, this can be done better somewhere for cairo */
-#if GTK_CHECK_VERSION (3, 0, 0)
-                value_width = req.width + COLUMN_SPACING + 10;
-                value_height = req.height + ROW_SPACING + 10;
-#else
                 value_width = req.width + COLUMN_SPACING;
                 value_height = req.height + ROW_SPACING;
-#endif
 
                 /* make sure all widths and heights are non zero,
                  * otherwise will get a divide by zero exception below
@@ -537,16 +534,7 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
                  * widgets directly */
                 gtk_widget_size_request(GTK_WIDGET(first_sensor->value),
                                         &req);
-/* FIXME, this can be done better somewhere for cairo */
-#if GTK_CHECK_VERSION (3, 0, 0)
-                value_width = req.width + COLUMN_SPACING + 10;
-                value_height = req.height + ROW_SPACING + 10;
 
-                gtk_widget_size_request(GTK_WIDGET(first_sensor->label),
-                                        &req);
-                label_width = req.width + COLUMN_SPACING + 10;
-                label_height = req.height + ROW_SPACING + 10;
-#else
                 value_width = req.width + COLUMN_SPACING;
                 value_height = req.height + ROW_SPACING;
 
@@ -554,7 +542,6 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
                                         &req);
                 label_width = req.width + COLUMN_SPACING;
                 label_height = req.height + ROW_SPACING;
-#endif
         
                 /* make sure all widths and heights are non zero, otherwise
                  * will get a divide by zero exception below 
@@ -585,16 +572,6 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
         case DISPLAY_ICON_WITH_VALUE:
                 gtk_widget_size_request(GTK_WIDGET(first_sensor->value),
                                         &req);
-/* FIXME, this can be done better somewhere for cairo */
-#if GTK_CHECK_VERSION (3, 0, 0)
-                value_width = req.width + COLUMN_SPACING +10;
-                value_height = req.height + ROW_SPACING + 10;
-
-                gtk_widget_size_request(GTK_WIDGET(first_sensor->icon),
-                                        &req);
-                icon_width = req.width + COLUMN_SPACING + 10;
-                icon_height = req.height + ROW_SPACING + 10;
-#else
                 value_width = req.width + COLUMN_SPACING;
                 value_height = req.height + ROW_SPACING;
 
@@ -602,7 +579,6 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
                                         &req);
                 icon_width = req.width + COLUMN_SPACING;
                 icon_height = req.height + ROW_SPACING;
-#endif
                 
                 if (!(icon_width && icon_height &&
                       value_width && value_height)) {
@@ -628,14 +604,9 @@ static void sensors_applet_pack_display(SensorsApplet *sensors_applet) {
         case DISPLAY_ICON:
                 gtk_widget_size_request(GTK_WIDGET(first_sensor->icon),
                                         &req);
-/* FIXME, this can be done better somewhere for cairo */
-#if GTK_CHECK_VERSION (3, 0, 0)
-                icon_width = req.width + COLUMN_SPACING + 10;
-                icon_height = req.height + ROW_SPACING + 10;
-#else
                 icon_width = req.width + COLUMN_SPACING;
                 icon_height = req.height + ROW_SPACING;
-#endif
+
                 if (!(icon_width && icon_height)) {
                         return;
                 }


### PR DESCRIPTION
This basically reverts 22f0f60d2f7e8290aec0c8fe0d2667123430d746 but I have proper sensors showing with icon and label under Gtk3.

@NiceandGently please confirm the sensors are still ok for you with Gtk3.