### PR TITLE
Update tooltip only when mouse is over the applet

### DIFF
--- a/sensors-applet/active-sensor.c
+++ b/sensors-applet/active-sensor.c
@@ -646,7 +646,8 @@ void active_sensor_update(ActiveSensor *active_sensor,
                         } /* end else on error */
 
                         /* setup for tooltips */
-                        tooltip = g_strdup_printf("%s %s", sensor_label, value_tooltip);
+                        if (sensors_applet->show_tooltip)
+                                tooltip = g_strdup_printf("%s %s", sensor_label, value_tooltip);
                         g_free(value_tooltip);
 
                         /* only do icons and labels / graphs if needed */
@@ -667,10 +668,11 @@ void active_sensor_update(ActiveSensor *active_sensor,
                                         active_sensor->sensor_low_value = sensor_low_value;
                                         active_sensor->sensor_high_value = sensor_high_value;                                
                                         active_sensor_update_icon(active_sensor, icon_pixbuf, sensor_type);
-                                } 
-                                /* always update tooltip */
-                                gtk_widget_set_tooltip_text(active_sensor->icon,
-                                                            tooltip);
+                                }
+                                if (tooltip) {
+                                        gtk_widget_set_tooltip_text(active_sensor->icon,
+                                                                    tooltip);
+                                }
                         }
                         active_sensor_update_sensor_value(active_sensor,
                                                           sensor_value);
@@ -684,8 +686,10 @@ void active_sensor_update(ActiveSensor *active_sensor,
                                                 &(active_sensor->graph_color));
                                 
                                 gtk_widget_queue_draw (active_sensor->graph);
-                                gtk_widget_set_tooltip_text(active_sensor->graph,
-                                                            tooltip);
+                                if (tooltip) {
+                                        gtk_widget_set_tooltip_text(active_sensor->graph,
+                                                                    tooltip);
+                                }
                                 
                         }
 
@@ -733,10 +737,10 @@ void active_sensor_update(ActiveSensor *active_sensor,
                                 }
                                 gtk_label_set_markup(GTK_LABEL(active_sensor->value),
                                                      value_text);
-                        
-			
-                                gtk_widget_set_tooltip_text(active_sensor->value,
-                                                            tooltip);
+                                if (tooltip) {
+                                        gtk_widget_set_tooltip_text(active_sensor->value,
+                                                                    tooltip);
+                                }
                         }
                         /* finished with value text */
                         g_free(value_text);
@@ -750,8 +754,10 @@ void active_sensor_update(ActiveSensor *active_sensor,
                                 }
                                 gtk_label_set_markup(GTK_LABEL(active_sensor->label),
                                                      sensor_label);
-                                gtk_widget_set_tooltip_text(active_sensor->label,
-                                                            tooltip);
+                                if (tooltip) {
+                                        gtk_widget_set_tooltip_text(active_sensor->label,
+                                                                    tooltip);
+                                }
 
                         }
 

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -217,6 +217,25 @@ static void style_set_cb(GtkWidget *widget,
             
 }
 
+static gboolean mouse_enter_cb(GtkWidget *widget,
+                               GdkEventCrossing *event,
+                               gpointer data)
+{
+        SensorsApplet *sensor_applet = data;
+        sensor_applet->show_tooltip = TRUE;
+        sensors_applet_update_active_sensors(sensor_applet);
+        return TRUE;
+}
+
+static gboolean mouse_leave_cb(GtkWidget *widget,
+                               GdkEventCrossing *event,
+                               gpointer data)
+{
+        SensorsApplet *sensor_applet = data;
+        sensor_applet->show_tooltip = FALSE;
+        return TRUE;
+}
+
 static const GtkActionEntry sensors_applet_menu_actions[] = {
 	{ "Preferences", GTK_STOCK_PROPERTIES, N_("_Preferences"),
 		NULL, NULL,
@@ -1372,6 +1391,13 @@ void sensors_applet_init(SensorsApplet *sensors_applet) {
                           G_CALLBACK(size_allocate_cb), 
                           sensors_applet);
 
+        g_signal_connect(G_OBJECT(sensors_applet->applet), "leave_notify_event",
+                         G_CALLBACK(mouse_leave_cb),
+                         (gpointer)sensors_applet);
+
+        g_signal_connect(G_OBJECT(sensors_applet->applet), "enter_notify_event",
+                         G_CALLBACK(mouse_enter_cb),
+                         (gpointer)sensors_applet);
 
 
 	sensors_applet_update_active_sensors(sensors_applet);

--- a/sensors-applet/sensors-applet.h
+++ b/sensors-applet/sensors-applet.h
@@ -141,6 +141,8 @@ struct _SensorsApplet {
 #ifdef HAVE_LIBNOTIFY
         NotifyNotification *notification;
 #endif // HAVE_LIBNOTIFY
+
+        gboolean show_tooltip;
 };
 
 


### PR DESCRIPTION
This can prevent problems with OpenGL on some drivers. The problem is
described here: https://github.com/mate-desktop/mate-panel/issues/397

This also updates all sensors when mouse enters the applet to get
updated values.