### PR TITLE
fix some deprecations

### DIFF
--- a/sensors-applet/prefs-dialog.c
+++ b/sensors-applet/prefs-dialog.c
@@ -70,7 +70,11 @@ void prefs_dialog_response(GtkDialog *prefs_dialog,
 				       ((current_page == 1) ?
 					"sensors-applet-sensors" :
 					NULL)));
+#if GTK_CHECK_VERSION (3, 22, 0)
+                gtk_show_uri_on_window(NULL, uri, gtk_get_current_event_time(), &error);
+#else
                 gtk_show_uri(NULL, uri, gtk_get_current_event_time(), &error);
+#endif
 		g_free(uri);
 
                 if (error) {

--- a/sensors-applet/sensor-config-dialog.c
+++ b/sensors-applet/sensor-config-dialog.c
@@ -79,11 +79,15 @@ static void sensor_config_dialog_response(GtkDialog *dialog,
         switch (response) {
         case GTK_RESPONSE_HELP:
                 g_debug("loading help in config dialog");
+#if GTK_CHECK_VERSION (3, 22, 0)
+                gtk_show_uri_on_window(NULL,
+#else
                 gtk_show_uri(NULL,
+#endif
 			     "help:mate-sensors-applet/sensors-applet-sensors#sensors-applet-sensor-config-dialog",
 			     gtk_get_current_event_time(),
 			     &error);
-                
+
                 if (error) {
                         g_debug("Could not open help document: %s ",error->message);
                         g_error_free (error);

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -378,7 +378,7 @@ void sensors_applet_notify_active_sensor(ActiveSensor *active_sensor, NotifType 
                                        notif_type,
                                        summary,
                                        message,
-                                       GTK_STOCK_DIALOG_WARNING,
+                                       "dialog-warning",
                                        timeout_msecs);
         
         g_free(sensor_path);

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -77,8 +77,12 @@ static void help_cb(GtkAction *action,
                     gpointer data) {
 
         GError *error = NULL;
-        
+
+#if GTK_CHECK_VERSION (3, 22, 0)
+        gtk_show_uri_on_window(NULL, "help:mate-sensors-applet",
+#else
         gtk_show_uri(NULL, "help:mate-sensors-applet",
+#endif
 		     gtk_get_current_event_time(),
 		     &error);
         


### PR DESCRIPTION
Please test.
Note, for testing the help link in sensors-config-dialog you need to edit the link because of
https://bugzilla.gnome.org/show_bug.cgi?id=778553
At line
https://github.com/mate-desktop/mate-sensors-applet/blob/master/sensors-applet/sensor-config-dialog.c#L83
use that for example
```
"help:mate-sensors-applet/sensors-applet-sensor-config-dialog"
```
