### PR TITLE
i46 fix save order of sensors

### DIFF
--- a/org.mate.sensors-applet.gschema.xml.in
+++ b/org.mate.sensors-applet.gschema.xml.in
@@ -32,9 +32,10 @@
       <default>42</default>
       <summary>The size of the graph in pixels (width if horizontal, height if vertical)</summary>
     </key>
-    <key name="sensors-list" type="as">
+    <key name="sensors-list" type="a(ssssbddbssuuddus)">
       <default>[]</default>
-      <summary>List of sensors</summary>
+      <summary>Array holding sensors data</summary>
+      <description>Serialized data of the sensors info.</description>
     </key>
   </schema>
 </schemalist>

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -1350,6 +1350,10 @@ void sensors_applet_init(SensorsApplet *sensors_applet) {
 	sensors_applet->settings = mate_panel_applet_settings_new (sensors_applet->applet,
 								   "org.mate.sensors-applet");
 
+        // load sensors from array saved in gsettings
+        sensors_applet_conf_setup_sensors(sensors_applet);
+
+
 	/* now do any setup needed manually */
         sensors_applet_plugins_load_all(sensors_applet);        
 


### PR DESCRIPTION
This is a preliminary patch for #46 
It seems to work, but please do not merge it just yet.

I have the following problems:
sensors-applet-settings.c
(NOT IMPORTANT) replace g_variant_builder_add_value()
> a nicer function to use, but so far I couldn't get it to work
solved locally

(KINDA IMPORTANT) replace "(ssssbddbssuuddus)" with variable
> this gvariant format string is everywhere, thus should be somewhere as a variable and only once
solved locally using #define

(NOT THAT IMPORTANT) version support? for config data
> in gsa the version is saved, so that the sensor data can be validated, before loading it into the program from gsettings. AFAIK This problem can be mitigated by removing msa from the mate-panel and adding it again OR by changing the gsettings sensors-list value to an empty array: [], then opening and closing the preferences dialog, as that saves the (new or correct) sensor data to gsettings. Furthermore I don't think, that the sensor data stored is going to change much.

(VERY IMPORTANT) duplicate sensor data stored
  This is where I am going to need some help. With this fix, the setup data for the sensors is stored **twice** in gsettings. The original one stores sensors as hash -> sensor data pairs.
![screenshot at 2017-10-21 14-34-44](https://user-images.githubusercontent.com/31438307/31851776-19f9950e-b66d-11e7-825b-a7224aebecf2.png)
AFAIK This saves no sorting information.
If it does, it does not load it.

My fix adds the gsa saving mechanism, where the sensor data is saved as a gvariant array.
![screenshot at 2017-10-21 14-35-10](https://user-images.githubusercontent.com/31438307/31851792-4ab7cf08-b66d-11e7-9d5a-d1aaae12d8ff.png)
This saves and loads the sensors, sorted.

Which one should we keep? Suggestions?

NOTE:
I came across a problem, while I was working on the saving part.
Syslog said:
g_settings_set_value: key 'sensors-list' in 'org.mate.sensors-applet' expects type 'as', but a GVariant of type 'a(ssssbddbssuuddus)' was given

I have changed the gsettings schema to be able to save the sensor data the gsa way.
However this didn't get installed into my system.
I had to do the following manually: (maybe a restart makes this unnecessary)
Found out that the file
/usr/local/share/glib-2.0/schemas/org.mate.sensors-applet.gschema.xml
is unchanged after make install, so changed it:

    <key name="sensors-list" type="as">
      <default>[]</default>
      <summary>List of sensors</summary>
    </key>

to:

    <key name="sensors-list" type="a(ssssbddbssuuddus)">
      <default>[]</default>
      <summary>Array holding sensors data</summary>
      <description>Serialized data of the sensors info.</description>
    </key>

used sudo glib-compile-schemas to recompile binary file in the same folder
https://developer.gnome.org/gio/stable/glib-compile-schemas.html

save worked after restart