### PR TITLE
i46 fix save order of sensors

### DIFF
--- a/sensors-applet/sensors-applet-plugins.c
+++ b/sensors-applet/sensors-applet-plugins.c
@@ -83,7 +83,8 @@ static void load_all_plugins(SensorsApplet *sensors_applet,
                                                                                           sensor_info->offset,
                                                                                           sensor_info->icon,
                                                                                           sensor_info->graph_color);
-                                                                
+
+                                                                // sensors_applet_add_sensor() doesn't free strings, so free them here
                                                                 g_free(sensor_info->path);
                                                                 g_free(sensor_info->id);
                                                                 g_free(sensor_info->label);

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -872,6 +872,7 @@ GdkPixbuf *sensors_applet_load_icon(IconType icon_type) {
         return icon;
 }
 
+// MUST FREE STRINGS AFTER CALLING THIS FUNCTION!!
 gboolean sensors_applet_add_sensor(SensorsApplet *sensors_applet,
                                    const gchar *path, 
                                    const gchar *id, 
@@ -1016,13 +1017,11 @@ gboolean sensors_applet_add_sensor(SensorsApplet *sensors_applet,
 	
 	/* if sensor is already in settings, load values from there */
 	gchar *applet_path = mate_panel_applet_get_preferences_path (sensors_applet->applet);
-	gchar *settings_path = g_strdup_printf ("%s%s/",
-				applet_path,
-				sensors_applet_settings_get_unique_id (interface,
-								       id,
-								       path));
+        gchar *gsuid = sensors_applet_settings_get_unique_id (interface, id, path);
+	gchar *settings_path = g_strdup_printf ("%s%s/", applet_path, gsuid);
 	GSettings *settings = g_settings_new_with_path ("org.mate.sensors-applet.sensor", settings_path);
 	g_free (applet_path);
+        g_free (gsuid);
 	g_free (settings_path);
 	
 	gchar *settings_id = g_settings_get_string (settings, ID);
@@ -1349,6 +1348,10 @@ void sensors_applet_init(SensorsApplet *sensors_applet) {
 	/* init gsettings */
 	sensors_applet->settings = mate_panel_applet_settings_new (sensors_applet->applet,
 								   "org.mate.sensors-applet");
+
+        // load sensors from array saved in gsettings
+        sensors_applet_conf_setup_sensors(sensors_applet);
+
 
 	/* now do any setup needed manually */
         sensors_applet_plugins_load_all(sensors_applet);        


### PR DESCRIPTION
Sorry, I remade this branch because my commit name wasn't right and my local repo was a mess.
I've just copied the info from the other one here.

This is a preliminary patch for #46 
It seems to work, but please do not merge it just yet.

I have the following problems:
sensors-applet-settings.c
(NOT IMPORTANT) replace g_variant_builder_add_value()
> a nicer function to use, but so far I couldn't get it to work
solved

(KINDA IMPORTANT) replace "(ssssbddbssuuddus)" with variable
> this gvariant format string is everywhere, thus should be somewhere as a variable and only once
solved using #define

(NOT THAT IMPORTANT) version support? for config data
> in gsa the version is saved, so that the sensor data can be validated, before loading it into the program from gsettings. AFAIK This problem can be mitigated by removing msa from the mate-panel and adding it again OR by changing the gsettings sensors-list value to an empty array: [], then opening and closing the preferences dialog, as that saves the (new or correct) sensor data to gsettings. Furthermore I don't think, that the sensor data stored is going to change much.

(VERY IMPORTANT) duplicate sensor data stored
  This is where I am going to need some help. With this fix, the setup data for the sensors is stored **twice** in gsettings. The original one stores sensors as hash -> sensor data pairs.
![screenshot at 2017-10-21 14-34-44](https://user-images.githubusercontent.com/31438307/31851776-19f9950e-b66d-11e7-825b-a7224aebecf2.png)
AFAIK This saves no sorting information.
If it does, it does not load it.

My fix adds the gsa saving mechanism, where the sensor data is saved as a gvariant array.
![screenshot at 2017-10-21 14-35-10](https://user-images.githubusercontent.com/31438307/31851792-4ab7cf08-b66d-11e7-9d5a-d1aaae12d8ff.png)
This saves and loads the sensors, sorted.

Which one should we keep? Suggestions?

NOTE:
I came across a problem, while I was working on the saving part.
Syslog said:
g_settings_set_value: key 'sensors-list' in 'org.mate.sensors-applet' expects type 'as', but a GVariant of type 'a(ssssbddbssuuddus)' was given

I have changed the gsettings schema to be able to save the sensor data the gsa way.
However this didn't get installed into my system.
I had to do the following manually: (maybe a restart makes this unnecessary)
Found out that the file
/usr/local/share/glib-2.0/schemas/org.mate.sensors-applet.gschema.xml
is unchanged after make install, so changed it:

    <key name="sensors-list" type="as">
      <default>[]</default>
      <summary>List of sensors</summary>
    </key>

to:

    <key name="sensors-list" type="a(ssssbddbssuuddus)">
      <default>[]</default>
      <summary>Array holding sensors data</summary>
      <description>Serialized data of the sensors info.</description>
    </key>

used sudo glib-compile-schemas to recompile binary file in the same folder
https://developer.gnome.org/gio/stable/glib-compile-schemas.html

save worked after restart