### PR TITLE
active-sensor.c: Fix build warning:

### DIFF
--- a/sensors-applet/active-sensor.c
+++ b/sensors-applet/active-sensor.c
@@ -421,7 +421,7 @@ ActiveSensor *active_sensor_new(SensorsApplet *sensors_applet,
     active_sensor->sensor_row = sensor_row;
 
     int i;
-    for (i = 0; i < NUM_NOTIFS; i++) {
+    for (i = 0; i < NUM_ALARMS; i++) {
         active_sensor->alarm_timeout_id[i] = -1;
     }
 


### PR DESCRIPTION
Fixes the build warning: "iteration 2 invokes undefined behavior"