### PR TITLE
udisks-plugin.c: Fix build warnings:

### DIFF
--- a/plugins/udisks/udisks-plugin.c
+++ b/plugins/udisks/udisks-plugin.c
@@ -227,8 +227,8 @@ static void udisks_plugin_get_sensors(GList **sensors) {
                                         G_CALLBACK(udisks_changed_signal_cb),
                                         path, NULL);
 
-            gchar *model = g_value_get_string(&model_v);
-            gchar *dev = g_value_get_string(&dev_v);
+            gchar *model = (gchar *) g_value_get_string(&model_v);
+            gchar *dev = (gchar *) g_value_get_string(&dev_v);
             GStrv ids = g_value_get_boxed(&ids_v);
 
             gchar *id = ids != NULL && ids[0] != NULL ? ids[0] : dev;


### PR DESCRIPTION
Fixes the build warnings:

```
udisks-plugin.c: In function ‘udisks_plugin_get_sensors’:
udisks-plugin.c:230:28: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
             gchar *model = g_value_get_string(&model_v);
                            ^~~~~~~~~~~~~~~~~~
udisks-plugin.c:231:26: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
             gchar *dev = g_value_get_string(&dev_v);
                          ^~~~~~~~~~~~~~~~~~
```

@info-cppsp please test