### PR TITLE
Fix popup shower on removed HDD

### DIFF
--- a/sensors-applet/active-sensor.c
+++ b/sensors-applet/active-sensor.c
@@ -420,6 +420,11 @@ ActiveSensor *active_sensor_new(SensorsApplet *sensors_applet,
 
     active_sensor->sensor_row = sensor_row;
 
+#ifdef HAVE_LIBNOTIFY
+    /* set a base time, creation -5 minutes */
+    active_sensor->ierror_ts = time(NULL) - 300;
+#endif
+
     int i;
     for (i = 0; i < NUM_ALARMS; i++) {
         active_sensor->alarm_timeout_id[i] = -1;

--- a/sensors-applet/active-sensor.h
+++ b/sensors-applet/active-sensor.h
@@ -20,6 +20,7 @@
 #define ACTIVE_SENSOR_H
 
 #ifdef HAVE_LIBNOTIFY
+#include <time.h>
 #include <libnotify/notify.h>
 #include "active-sensor-libnotify.h"
 #endif
@@ -42,6 +43,8 @@ struct _ActiveSensor {
 
 #ifdef HAVE_LIBNOTIFY
     NotifyNotification *notification[NUM_NOTIFS];
+    /* error timestamp - save the time of the last SENSOR_INTERFACE_ERROR */
+    time_t ierror_ts;
 #endif
 
     gboolean updated;

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -272,6 +272,8 @@ void sensors_applet_notify_active_sensor(ActiveSensor *active_sensor, NotifType 
     const gchar *limit_type = NULL;
     const gchar *units = NULL;
     gdouble limit_value;
+    gdouble seconds;
+    gboolean show_notification = TRUE;
 
     sensors_applet = active_sensor->sensors_applet;
 
@@ -365,21 +367,35 @@ void sensors_applet_notify_active_sensor(ActiveSensor *active_sensor, NotifType 
             break;
 
         case SENSOR_INTERFACE_ERROR:
+            /* get time since the last error */
+            seconds = difftime(time(NULL), active_sensor->ierror_ts);
+
+            /* if the last error happened less than 10 seconds ago, don't display this one
+             * this should prevent recurring popups for removed sensors, like USB-HDDs */
+            if (seconds < 11.0) {
+                show_notification = FALSE;
+            }
+
             summary = g_strdup_printf(_("Error updating sensor %s"), sensor_label);
             message = g_strdup_printf(_("An error occurred while trying to update the value of the sensor %s located at %s."), sensor_label, sensor_path);
             timeout_msecs = g_settings_get_int (active_sensor->sensors_applet->settings, TIMEOUT);
+
+            /* update timestamp */
+            time(&(active_sensor->ierror_ts));
             break;
 
         default:
             g_assert_not_reached();
     }
 
-    active_sensor_libnotify_notify(active_sensor,
-                                   notif_type,
-                                   summary,
-                                   message,
-                                   "dialog-warning",
-                                   timeout_msecs);
+    if (show_notification) {
+        active_sensor_libnotify_notify(active_sensor,
+                                       notif_type,
+                                       summary,
+                                       message,
+                                       "dialog-warning",
+                                       timeout_msecs);
+    }
 
     g_free(sensor_path);
     g_free(sensor_label);


### PR DESCRIPTION
Added timer to active sensors, to suppress infinite popups, when a drive is removed from the system, with its sensor still active in msa.
fixes #62