### PR TITLE
nvidia plugin: get cooler RPM instead of percentage

### DIFF
--- a/plugins/nvidia/nvidia-plugin.c
+++ b/plugins/nvidia/nvidia-plugin.c
@@ -32,7 +32,7 @@
 const gchar *plugin_name = "nvidia";
 
 #define THERMAL_SENSOR_TEMP "SensorTemp"
-#define THERMAL_COOLER_LEVEL "CoolerLevel"
+#define THERMAL_COOLER_SPEED "CoolerSpeed"
 #define GPU_CORE_TEMP "CoreTemp"
 #define AMBIENT_TEMP "AmbientTemp"
 
@@ -58,12 +58,12 @@ static gdouble nvidia_plugin_get_sensor_value(const gchar *path,
                           NV_CTRL_THERMAL_SENSOR_READING,
                           &temp);
 
-    } else if (g_ascii_strcasecmp(path, THERMAL_COOLER_LEVEL) == 0) {
+    } else if (g_ascii_strcasecmp(path, THERMAL_COOLER_SPEED) == 0) {
         res = XNVCTRLQueryTargetAttribute(nvidia_sensors_dpy,
                           NV_CTRL_TARGET_TYPE_COOLER,
                           i,
                           0,
-                          NV_CTRL_THERMAL_COOLER_LEVEL,
+                          NV_CTRL_THERMAL_COOLER_SPEED,
                           &temp);
 
     } else if (g_ascii_strcasecmp(path, GPU_CORE_TEMP) == 0) {
@@ -140,10 +140,10 @@ static GList *nvidia_plugin_init(void) {
                         &cnt)) {
 
             for (i = 0; i < cnt; i++) {
-                gchar *id = g_strdup_printf("GPU%d%s", i, THERMAL_COOLER_LEVEL);
+                gchar *id = g_strdup_printf("GPU%d%s", i, THERMAL_COOLER_SPEED);
 
                 sensors_applet_plugin_add_sensor(&sensors,
-                                                 THERMAL_COOLER_LEVEL,
+                                                 THERMAL_COOLER_SPEED,
                                                  id,
                                                  _("GPU"),
                                                  FAN_SENSOR,


### PR DESCRIPTION
This should fix https://github.com/mate-desktop/mate-sensors-applet/issues/84. Unfortunately, I can't test it myself. My home GT 730 doesn't expose fan data at all, and another GT 730 at work only exposes fan level in percentage.

Requirements:
- nvidia card with fan
- proprietary drivers
- libxnvctrl >= 331.13

If your card supports exposing fan data, there should be a new CoolerSpeed sensor in the applet's prefs dialog. It replaces CoolerLevel sensor. Yes, I've renamed it to match its purpose.

The sensor should show the same fan speed as `nvidia-settings` does.