### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # ================= initialization =================== #
 
-AC_INIT([MATE Sensors Applet], [1.22.0], [http://www.mate-desktop.org],
+AC_INIT([MATE Sensors Applet], [1.22.0], [https://mate-desktop.org],
 [mate-sensors-applet])
 
 AC_CONFIG_SRCDIR([sensors-applet/main.c])

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -18,7 +18,7 @@
 <!-- 
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
-  http://www.mate-desktop.org/development/
+  https://mate-desktop.org/development/
   Template version: 2.0 beta
   Template last modified Feb 06, 2003
 -->

--- a/sensors-applet/about-dialog.c
+++ b/sensors-applet/about-dialog.c
@@ -45,7 +45,7 @@ void about_dialog_open(SensorsApplet *sensors_applet) {
                   /* To translator: Put your name here to show up in the About dialog as the translator */
                   "translator-credits", _("translator-credits"),
                   "logo-icon-name", SENSORS_APPLET_ICON,
-                  "website", "http://www.mate-desktop.org",
+                  "website", "https://mate-desktop.org",
                   NULL);
 
 }


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.