### PR TITLE
Remove unused-variable warning

### DIFF
--- a/plugins/acpi/acpi-plugin.c
+++ b/plugins/acpi/acpi-plugin.c
@@ -41,7 +41,6 @@ enum {
 static void acpi_plugin_add_sensor(GList **sensors, const gchar *path) {
     gchar *dirname;
     gchar *id;
-    gchar *label;
 
 
     dirname = g_path_get_dirname(path);

--- a/plugins/libsensors/libsensors-plugin.c
+++ b/plugins/libsensors/libsensors-plugin.c
@@ -402,7 +402,6 @@ static gdouble libsensors_plugin_get_sensor_value(const gchar *path,
     if (regexec (&uri_re, path, 3, m, 0) == 0) {
         const sensors_chip_name *found_chip;
         int feature;
-        int i;
 
         if ((found_chip = g_hash_table_lookup(hash_table, path)) != NULL) {
             gdouble value;

--- a/sensors-applet/sensor-config-dialog.c
+++ b/sensors-applet/sensor-config-dialog.c
@@ -317,7 +317,6 @@ static void sensor_config_dialog_graph_color_set(GtkColorChooser *color_chooser,
     GtkTreeModel *model;
     GtkTreePath *path;
     GtkTreeIter iter;
-    GtkWidget *content_area;
     gchar *color_string;
     GdkRGBA color;
 


### PR DESCRIPTION
```
sensor-config-dialog.c:320:16: warning: unused variable ‘content_area’ [-Wunused-variable]
  320 |     GtkWidget *content_area;
      |                ^~~~~~~~~~~~
--
acpi-plugin.c:44:12: warning: unused variable ‘label’ [-Wunused-variable]
   44 |     gchar *label;
      |            ^~~~~
--
libsensors-plugin.c:405:13: warning: unused variable ‘i’ [-Wunused-variable]
  405 |         int i;
      |             ^
```