### PR TITLE
help: fix DE name and link to GPL

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -640,7 +640,7 @@ Alarms for individual sensors must also be enabled.
   manual, this is the place to put it. Alternatively, you can put this 
   information in the title page.-->
 
-  <sect1 id="myapplet-about">
+  <sect1 id="sensors-applet-about">
     <title>About &applet;</title>
     <para> The origin sensor applet was written by Alex Murray
       (<email>murray.alex@gmail.com</email>).

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -644,7 +644,7 @@ Alarms for individual sensors must also be enabled.
     <title>About &applet;</title>
     <para> The origin sensor applet was written by Alex Murray
       (<email>murray.alex@gmail.com</email>).
-      <application>&applet;</application> is further develop by Mate dev team.
+      <application>&applet;</application> is further develop by MATE Dev team.
       To find more information about
       <application>&applet;</application>, please visit the <ulink
         url="&project-webpage;" type="http">&applet; Project
@@ -670,7 +670,7 @@ Alarms for individual sensors must also be enabled.
       Public license as published by the Free Software Foundation;
       either version 2 of the License, or (at your option) any later
       version. A copy of this license can be found at this <ulink
-	type="help" url="help:gpl">link</ulink>, or in the file COPYING
+	type="https" url="https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">link</ulink>, or in the file COPYING
       included with the source code of this program. 
     </para>
   </sect1> 


### PR DESCRIPTION
* Fixes desktop environment name
* Link to GPL is now a plaintext link on the web, since the docbook link `help:gpl` is broken