### PR TITLE
libsensors-plugin: function declaration isn't a prototype

### DIFF
--- a/plugins/libsensors/libsensors-plugin.c
+++ b/plugins/libsensors/libsensors-plugin.c
@@ -435,7 +435,7 @@ static gdouble libsensors_plugin_get_sensor_value(const gchar *path,
 }
 
 
-static GList *libsensors_plugin_init() {
+static GList *libsensors_plugin_init(void) {
     GError *err = NULL;
 
     /* compile the regular expressions */


### PR DESCRIPTION
```
libsensors-plugin.c:438:15: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  438 | static GList *libsensors_plugin_init() {
      |               ^~~~~~~~~~~~~~~~~~~~~~
```