### PR TITLE
hddtemp & mbmon plugins: 'GTimeVal' is deprecated

### DIFF
--- a/plugins/hddtemp/hddtemp-plugin.c
+++ b/plugins/hddtemp/hddtemp-plugin.c
@@ -67,19 +67,19 @@ static const gchar *hddtemp_plugin_query_hddtemp_daemon(GError **error) {
     gchar *pc;
 
     struct sockaddr_in address;
-    static GTimeVal previous_query_time;
-    GTimeVal current_query_time;
+    static gint64 previous_query_time;
+    gint64 current_query_time;
 
     if (first_run) {
         // initialise previous time
-        g_get_current_time(&previous_query_time);
+        previous_query_time = g_get_monotonic_time ();
     }
-    g_get_current_time(&current_query_time);
+    current_query_time = g_get_monotonic_time ();
 
     /* only actually query if more than 60 seconds has elapsed as
     hddtemp daemon will only actually send a new value if is > 60
     seconds */
-    if (first_run || current_query_time.tv_sec - previous_query_time.tv_sec > 60) {
+    if (first_run || current_query_time - previous_query_time > G_TIME_SPAN_MINUTE) {
         previous_query_time = current_query_time;
 
         if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {

--- a/plugins/mbmon/mbmon-plugin.c
+++ b/plugins/mbmon/mbmon-plugin.c
@@ -62,20 +62,20 @@ static const gchar *mbmon_plugin_query_mbmon_daemon(GError **error) {
 
     struct sockaddr_in address;
     static char* buffer = NULL;
-    static GTimeVal previous_query_time;
-    GTimeVal current_query_time;
+    static gint64 previous_query_time;
+    gint64 current_query_time;
 
     if (NULL == buffer) {
         /* initialise buffer and current time */
         buffer = g_new0(char, MBMON_OUTPUT_BUFFER_LENGTH);
-        g_get_current_time(&previous_query_time);
+        previous_query_time = g_get_monotonic_time ();
         first_run = TRUE;
     }
-    g_get_current_time(&current_query_time);
+    current_query_time = g_get_monotonic_time ();
 
     /* only query if more than 2 seconds has elapsed,
     mbmon daemon will send a new value every 2 seconds */
-    if (first_run || current_query_time.tv_sec - previous_query_time.tv_sec > 2) {
+    if (first_run || current_query_time - previous_query_time > 2 * G_TIME_SPAN_SECOND) {
         previous_query_time = current_query_time;
 
         if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {


### PR DESCRIPTION
```
hddtemp-plugin.c:70:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   70 |     static GTimeVal previous_query_time;
      |     ^~~~~~

hddtemp-plugin.c:71:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   71 |     GTimeVal current_query_time;
      |     ^~~~~~~~

mbmon-plugin.c:65:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   65 |     static GTimeVal previous_query_time;
      |     ^~~~~~

mbmon-plugin.c:66:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
   66 |     GTimeVal current_query_time;
      |     ^~~~~~~~
```