### PR TITLE
Remove cppcheck warnings about the variable scope can be reduced

### DIFF
--- a/lib/sensors-applet-plugin.c
+++ b/lib/sensors-applet-plugin.c
@@ -32,10 +32,6 @@ extern const gchar *plugin_name;
 void sensors_applet_plugin_find_sensors(GList **sensors,
                                         const gchar *path,
                                         SensorsAppletPluginTestSensorFunc test_sensor) {
-    GDir *dir;
-    const gchar* new_file;
-    gchar *new_path;
-
     if (g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
         /* also test can actually open file for reading */
         if (access(path, R_OK) == 0) {
@@ -48,9 +44,14 @@ void sensors_applet_plugin_find_sensors(GList **sensors,
        for a sensor dir
     */
     if (g_file_test(path, G_FILE_TEST_IS_DIR) && !g_file_test(path, G_FILE_TEST_IS_SYMLINK)) {
-        dir = g_dir_open(path, 0, NULL);
-        if (dir != NULL) {
+        GDir *dir;
+
+        if ((dir = g_dir_open(path, 0, NULL)) != NULL) {
+            const gchar *new_file;
+
             while(NULL != (new_file = g_dir_read_name(dir))) {
+                gchar *new_path;
+
                 new_path = g_build_filename(path, new_file, NULL);
                 sensors_applet_plugin_find_sensors(sensors, new_path, test_sensor);
                 g_free(new_path);
@@ -63,9 +64,10 @@ void sensors_applet_plugin_find_sensors(GList **sensors,
 /* for error handling */
 GQuark sensors_applet_plugin_error_quark(void) {
     static GQuark quark = 0;
-    gchar *string;
 
     if (quark == 0) {
+        gchar *string;
+
         string = g_strdup_printf("%s-plugin-error", plugin_name);
         quark = g_quark_from_string(string);
         g_free(string);

--- a/plugins/hddtemp/hddtemp-plugin.c
+++ b/plugins/hddtemp/hddtemp-plugin.c
@@ -60,11 +60,8 @@ enum {
 static gchar buffer[HDDTEMP_OUTPUT_BUFFER_LENGTH];
 
 static const gchar *hddtemp_plugin_query_hddtemp_daemon(GError **error) {
-    int sockfd;
-    ssize_t n = 1;
     guint output_length = 0;
     static gboolean first_run = TRUE;
-    gchar *pc;
 
     struct sockaddr_in address;
     static gint64 previous_query_time;
@@ -80,6 +77,10 @@ static const gchar *hddtemp_plugin_query_hddtemp_daemon(GError **error) {
     hddtemp daemon will only actually send a new value if is > 60
     seconds */
     if (first_run || current_query_time - previous_query_time > G_TIME_SPAN_MINUTE) {
+        int sockfd;
+        ssize_t n;
+        gchar *pc;
+
         previous_query_time = current_query_time;
 
         if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {

--- a/plugins/ibm-acpi/ibm-acpi-plugin.c
+++ b/plugins/ibm-acpi/ibm-acpi-plugin.c
@@ -50,9 +50,8 @@ enum {
 
 
 static void ibm_acpi_plugin_setup_manually(GList **sensors) {
-    gchar *label;
-
     if (g_file_test(IBM_ACPI_TEMPERATURE_FILE, G_FILE_TEST_EXISTS)) {
+        gchar *label;
 
         /* with Ibm_Acpi have 8 fixed sensors, all accessed
            from the IBM_ACPI_TEMPERATURE_FILE */

--- a/plugins/mbmon/mbmon-plugin.c
+++ b/plugins/mbmon/mbmon-plugin.c
@@ -54,9 +54,7 @@ enum {
 };
 
 static const gchar *mbmon_plugin_query_mbmon_daemon(GError **error) {
-    int sockfd;
-    ssize_t n = 1;
-    gboolean first_run = FALSE;
+    static gboolean first_run = FALSE;
     gint output_length = 0;
     gchar *pc;
 
@@ -76,6 +74,9 @@ static const gchar *mbmon_plugin_query_mbmon_daemon(GError **error) {
     /* only query if more than 2 seconds has elapsed,
     mbmon daemon will send a new value every 2 seconds */
     if (first_run || current_query_time - previous_query_time > 2 * G_TIME_SPAN_SECOND) {
+        int sockfd;
+        ssize_t n;
+
         previous_query_time = current_query_time;
 
         if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
@@ -135,7 +136,7 @@ static void mbmon_plugin_get_sensors(GList **sensors) {
 
     GError *error = NULL;
     const gchar *mbmon_output;
-    gchar **output_vector = NULL, **pv, **pv2;
+    gchar **output_vector = NULL, **pv;
 
     mbmon_output = mbmon_plugin_query_mbmon_daemon(&error);
 
@@ -147,6 +148,8 @@ static void mbmon_plugin_get_sensors(GList **sensors) {
     pv = output_vector = g_strsplit(mbmon_output, "\n", -1);
 
     while(pv[0] != NULL) {
+        gchar **pv2;
+
         pv2 = g_strsplit(pv[0], ":", -1);
         gchar *name, *label;
         SensorType type;

--- a/sensors-applet/active-sensor.c
+++ b/sensors-applet/active-sensor.c
@@ -211,7 +211,7 @@ static void active_sensor_update_icon(ActiveSensor *active_sensor,
                                       GdkPixbuf *base_icon,
                                       SensorType sensor_type) {
 
-    GdkPixbuf *overlay_icon, *new_icon;
+    GdkPixbuf *new_icon;
     const gchar *overlay_icon_filename = NULL;
     SensorValueRange value_range;
 
@@ -231,6 +231,8 @@ static void active_sensor_update_icon(ActiveSensor *active_sensor,
 
     /* only load overlay if required */
     if (overlay_icon_filename) {
+        GdkPixbuf *overlay_icon;
+
         overlay_icon = gdk_pixbuf_new_from_file_at_size(overlay_icon_filename,
                                 DEFAULT_ICON_SIZE,
                                 DEFAULT_ICON_SIZE,
@@ -360,7 +362,6 @@ static void active_sensor_set_graph_dimensions(ActiveSensor *as,
                                                gint width,
                                                gint height) {
 
-    gdouble *old_values;
     gint num_samples, old_num_samples;
     gint graph_width, graph_height;
 
@@ -374,6 +375,8 @@ static void active_sensor_set_graph_dimensions(ActiveSensor *as,
     num_samples = graph_width;
 
     if (as->sensor_values) {
+        gdouble *old_values;
+
         old_values = as->sensor_values;
         old_num_samples = as->num_samples;
 
@@ -504,7 +507,6 @@ void active_sensor_update(ActiveSensor *active_sensor,
 
     /* to build the list of labels as we go */
     gchar *value_text = NULL;
-    gchar *old_value_text;
 
     TemperatureScale scale;
     DisplayMode display_mode;
@@ -668,7 +670,7 @@ void active_sensor_update(ActiveSensor *active_sensor,
                 }
             }
 
-            old_value_text = value_text;
+            gchar *old_value_text = value_text;
 
             if (sensor_alarm_enabled) {
                 if (sensor_value >= sensor_high_value || sensor_value <= sensor_low_value) {

--- a/sensors-applet/main.c
+++ b/sensors-applet/main.c
@@ -28,10 +28,11 @@ static gboolean sensors_applet_fill(MatePanelApplet *applet,
                                     const gchar *iid,
                                     gpointer data) {
 
-    SensorsApplet *sensors_applet;
     gboolean retval = FALSE;
 
     if (strcmp(iid, "SensorsApplet") == 0) {
+        SensorsApplet *sensors_applet;
+
         sensors_applet = g_new0(SensorsApplet, 1);
         sensors_applet->applet = applet;
         sensors_applet_init(sensors_applet);

--- a/sensors-applet/prefs-dialog.c
+++ b/sensors-applet/prefs-dialog.c
@@ -293,10 +293,11 @@ static void prefs_dialog_row_activated(GtkTreeView *view, GtkTreePath *path, Gtk
 static void prefs_dialog_sensor_up_button_clicked(GtkButton *button, PrefsDialog *prefs_dialog) {
     GtkTreeModel *model;
     GtkTreeIter iter;
-    GtkTreePath *path;
 
     if (gtk_tree_selection_get_selected(prefs_dialog->sensors_applet->selection, &model, &iter)) {
         /* if has no prev node set up button insentive */
+        GtkTreePath *path;
+
         path = gtk_tree_model_get_path(model, &iter);
         if (gtk_tree_path_prev(path)) {
 
@@ -349,10 +350,12 @@ static void prefs_dialog_selection_changed(GtkTreeSelection *selection,
                                            PrefsDialog *prefs_dialog) {
 
     GtkTreeIter iter;
-    GtkTreePath *path;
     GtkTreeModel *model;
+
     /* if there is a selection with no children make config button sensitive */
     if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
+        GtkTreePath *path;
+
         if (!gtk_tree_model_iter_has_child(model, &iter)) {
             gtk_widget_set_sensitive(GTK_WIDGET(prefs_dialog->sensor_config_button), TRUE);
         } else {

--- a/sensors-applet/sensor-config-dialog.c
+++ b/sensors-applet/sensor-config-dialog.c
@@ -283,13 +283,13 @@ static void sensor_config_dialog_icon_type_changed(GtkComboBox *icon_type_combo_
 
     GtkTreeModel *model;
     GtkTreeIter iter;
-    GtkTreePath *path;
 
     GdkPixbuf *new_icon;
     IconType icon_type;
 
     icons_model = gtk_combo_box_get_model(icon_type_combo_box);
     if (gtk_combo_box_get_active_iter(icon_type_combo_box, &icons_iter)) {
+        GtkTreePath *path;
 
         gtk_tree_model_get(icons_model, &icons_iter,
                            0, &new_icon,
@@ -351,7 +351,6 @@ void sensor_config_dialog_create(SensorsApplet *sensors_applet) {
 
     GtkListStore *icon_store;
     IconType count;
-    GdkPixbuf *pixbuf;
     GdkRGBA graph_color;
     gchar *sensor_label;
     gchar *header_text;
@@ -452,6 +451,8 @@ void sensor_config_dialog_create(SensorsApplet *sensors_applet) {
 
     /* populate list with icons */
     for (count = CPU_ICON; count < NUM_ICONS; count++) {
+        GdkPixbuf *pixbuf;
+
         pixbuf = sensors_applet_load_icon(count);
         if (pixbuf) {
             gtk_list_store_insert(icon_store, &iter, count);

--- a/sensors-applet/sensors-applet-plugins.c
+++ b/sensors-applet/sensors-applet-plugins.c
@@ -39,13 +39,13 @@ static void load_all_plugins(SensorsApplet *sensors_applet, const gchar *path) {
                 /* try and open plugin */
                 gchar *plugin_file;
                 void *handle;
-                SensorsAppletPluginName name_fn;
                 SensorsAppletPluginInit init_fn;
-                SensorsAppletPluginGetSensorValue get_value_fn;
 
                 plugin_file = g_strdup_printf("%s/%s", path, file);
                 g_debug("found %s in plugin directory", plugin_file);
                 if ((handle = dlopen(plugin_file, RTLD_NOW)) != NULL) {
+                    SensorsAppletPluginName name_fn;
+                    SensorsAppletPluginGetSensorValue get_value_fn;
 
                     if ((name_fn = dlsym(handle, "sensors_applet_plugin_name")) != NULL &&
                         (init_fn = dlsym(handle, "sensors_applet_plugin_init")) != NULL &&

--- a/sensors-applet/sensors-applet.c
+++ b/sensors-applet/sensors-applet.c
@@ -165,10 +165,8 @@ static void style_set_cb(GtkWidget *widget, GtkStyle *old_style, gpointer data) 
 
     /* update all icons in the sensors tree and update all active sensors */
     GtkTreeIter interfaces_iter, sensors_iter;
-    GtkTreePath *path;
     gboolean not_end_of_interfaces = TRUE, not_end_of_sensors = TRUE;
     IconType icon_type;
-    GdkPixbuf *new_icon;
     gboolean enabled;
     SensorsApplet *sensors_applet;
     DisplayMode display_mode;
@@ -188,6 +186,8 @@ static void style_set_cb(GtkWidget *widget, GtkStyle *old_style, gpointer data) 
                 not_end_of_sensors;
                 not_end_of_sensors = gtk_tree_model_iter_next(GTK_TREE_MODEL(sensors_applet->sensors), &sensors_iter)) {
 
+                GdkPixbuf *new_icon;
+
                 gtk_tree_model_get(GTK_TREE_MODEL(sensors_applet->sensors),
                                    &sensors_iter,
                                    ENABLE_COLUMN, &enabled,
@@ -206,6 +206,8 @@ static void style_set_cb(GtkWidget *widget, GtkStyle *old_style, gpointer data) 
                 if (enabled &&
                     (display_mode == DISPLAY_ICON ||
                      display_mode == DISPLAY_ICON_WITH_VALUE)) {
+
+                    GtkTreePath *path;
 
                     path = gtk_tree_model_get_path(GTK_TREE_MODEL(sensors_applet->sensors), &sensors_iter);
                     sensors_applet_icon_changed(sensors_applet, path);


### PR DESCRIPTION
```
lib/sensors-applet-plugin.c:35:11: style: The scope of the variable 'dir' can be reduced. [variableScope]
    GDir *dir;
          ^
lib/sensors-applet-plugin.c:36:18: style: The scope of the variable 'new_file' can be reduced. [variableScope]
    const gchar* new_file;
                 ^
lib/sensors-applet-plugin.c:37:12: style: The scope of the variable 'new_path' can be reduced. [variableScope]
    gchar *new_path;
           ^
lib/sensors-applet-plugin.c:66:12: style: The scope of the variable 'string' can be reduced. [variableScope]
    gchar *string;
           ^
--
plugins/hddtemp/hddtemp-plugin.c:63:9: style: The scope of the variable 'sockfd' can be reduced. [variableScope]
    int sockfd;
        ^
plugins/hddtemp/hddtemp-plugin.c:64:13: style: The scope of the variable 'n' can be reduced. [variableScope]
    ssize_t n = 1;
            ^
plugins/hddtemp/hddtemp-plugin.c:67:12: style: The scope of the variable 'pc' can be reduced. [variableScope]
    gchar *pc;
           ^
--
plugins/ibm-acpi/ibm-acpi-plugin.c:53:12: style: The scope of the variable 'label' can be reduced. [variableScope]
    gchar *label;
           ^
plugins/mbmon/mbmon-plugin.c:57:9: style: The scope of the variable 'sockfd' can be reduced. [variableScope]
    int sockfd;
        ^
plugins/mbmon/mbmon-plugin.c:58:13: style: The scope of the variable 'n' can be reduced. [variableScope]
    ssize_t n = 1;
            ^
plugins/mbmon/mbmon-plugin.c:138:43: style: The scope of the variable 'pv2' can be reduced. [variableScope]
    gchar **output_vector = NULL, **pv, **pv2;
                                          ^
--
sensors-applet/active-sensor.c:214:16: style: The scope of the variable 'overlay_icon' can be reduced. [variableScope]
    GdkPixbuf *overlay_icon, *new_icon;
               ^
sensors-applet/active-sensor.c:363:14: style: The scope of the variable 'old_values' can be reduced. [variableScope]
    gdouble *old_values;
             ^
sensors-applet/active-sensor.c:507:12: style: The scope of the variable 'old_value_text' can be reduced. [variableScope]
    gchar *old_value_text;
           ^
--
sensors-applet/main.c:31:20: style: The scope of the variable 'sensors_applet' can be reduced. [variableScope]
    SensorsApplet *sensors_applet;
                   ^
sensors-applet/prefs-dialog.c:296:18: style: The scope of the variable 'path' can be reduced. [variableScope]
    GtkTreePath *path;
                 ^
sensors-applet/prefs-dialog.c:352:18: style: The scope of the variable 'path' can be reduced. [variableScope]
    GtkTreePath *path;
                 ^
--
sensors-applet/sensor-config-dialog.c:286:18: style: The scope of the variable 'path' can be reduced. [variableScope]
    GtkTreePath *path;
                 ^
sensors-applet/sensor-config-dialog.c:354:16: style: The scope of the variable 'pixbuf' can be reduced. [variableScope]
    GdkPixbuf *pixbuf;
               ^
sensors-applet/sensors-applet-plugins.c:42:41: style: The scope of the variable 'name_fn' can be reduced. [variableScope]
                SensorsAppletPluginName name_fn;
                                        ^
sensors-applet/sensors-applet-plugins.c:44:51: style: The scope of the variable 'get_value_fn' can be reduced. [variableScope]
                SensorsAppletPluginGetSensorValue get_value_fn;
                                                  ^
--
sensors-applet/sensors-applet.c:168:18: style: The scope of the variable 'path' can be reduced. [variableScope]
    GtkTreePath *path;
                 ^
sensors-applet/sensors-applet.c:171:16: style: The scope of the variable 'new_icon' can be reduced. [variableScope]
    GdkPixbuf *new_icon;
               ^
sensors-applet/sensors-applet.c:862:18: style: The scope of the variable 'tree_path' can be reduced. [variableScope]
    GtkTreePath *tree_path;
                 ^
sensors-applet/sensors-applet.c:1044:18: style: The scope of the variable 'sensor_tree_path' can be reduced. [variableScope]
    GtkTreePath *sensor_tree_path;
                 ^
```