### PR TITLE
unconditionally include stdio.h and locale.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,6 @@ AC_SUBST(LIBS)
 AC_CHECK_HEADERS(
 	stdlib.h \
 	string.h \
-	stdio.h \
 	sys/types.h \
 	sys/socket.h \
 	netinet/in.h \

--- a/plugins/acpi/acpi-plugin.c
+++ b/plugins/acpi/acpi-plugin.c
@@ -21,10 +21,7 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "acpi-plugin.h"

--- a/plugins/i2c-proc/i2c-proc-plugin.c
+++ b/plugins/i2c-proc/i2c-proc-plugin.c
@@ -21,14 +21,8 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
-#ifdef HAVE_LOCALE_H
 #include <locale.h>
-#endif
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "i2c-proc-plugin.h"

--- a/plugins/i2c-sys/i2c-sys-plugin.c
+++ b/plugins/i2c-sys/i2c-sys-plugin.c
@@ -21,10 +21,7 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "i2c-sys-plugin.h"

--- a/plugins/i8k/i8k-plugin.c
+++ b/plugins/i8k/i8k-plugin.c
@@ -21,10 +21,7 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "i8k-plugin.h"

--- a/plugins/ibm-acpi/ibm-acpi-plugin.c
+++ b/plugins/ibm-acpi/ibm-acpi-plugin.c
@@ -21,10 +21,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "ibm-acpi-plugin.h"

--- a/plugins/omnibook/omnibook-plugin.c
+++ b/plugins/omnibook/omnibook-plugin.c
@@ -21,10 +21,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "omnibook-plugin.h"

--- a/plugins/pmu-sys/pmu-sys-plugin.c
+++ b/plugins/pmu-sys/pmu-sys-plugin.c
@@ -21,10 +21,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "pmu-sys-plugin.h"

--- a/plugins/smu-sys/smu-sys-plugin.c
+++ b/plugins/smu-sys/smu-sys-plugin.c
@@ -21,10 +21,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_STDIO_H
 #include <stdio.h>
-#endif /* HAVE_STDIO_H */
-
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "smu-sys-plugin.h"


### PR DESCRIPTION
On musl mate-sensor-applet fails to build with error message saying
"LC_NUMERIC undeclared". As suggested in issue #123, removing the include
guards around `#include <local.h>` and `#include <stdio.h>`

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>