### PR TITLE
port to in-process for wayland support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,13 +2,16 @@ SUBDIRS = sensors-applet lib plugins pixmaps po help
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
+APPLET_LOCATION = $(libdir)/mate-sensors-applet/libmate_sensors_applet.so
+
 appletdir =  $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in
 applet_DATA = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
@@ -16,15 +19,6 @@ $(applet_DATA): $(applet_in_files) Makefile
 
 uidir 		= $(datadir)/mate-sensors-applet/ui
 ui_DATA 	= SensorsApplet.xml
-
-servicedir = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.SensorsAppletFactory.service.in
-service_DATA = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.SensorsAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-		$< > $@
 
 gsettingsschema_in_files = \
 	org.mate.sensors-applet.gschema.xml.in \
@@ -35,7 +29,6 @@ gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
 
 CLEANFILES = $(applet_DATA) \
 	$(applet_in_files) \
-	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 
@@ -45,7 +38,6 @@ DISTCHECK_CONFIGURE_FLAGS = \
 
 EXTRA_DIST = $(ui_DATA) \
 	$(applet_in_files).in \
-	$(service_in_files) \
 	$(gsettingsschema_in_files) \
 	autogen.sh
 

--- a/org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in.in
+++ b/org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=SensorsAppletFactory
-Location=@LIBEXECDIR@/mate-sensors-applet
+InProcess=true
+Location=@APPLET_LOCATION@
 Name=Sensors Applet Factory
 Description=Sensors Applet Factory
 

--- a/org.mate.panel.applet.SensorsAppletFactory.service.in
+++ b/org.mate.panel.applet.SensorsAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.SensorsAppletFactory
-Exec=@LIBEXECDIR@/mate-sensors-applet

--- a/sensors-applet/Makefile.am
+++ b/sensors-applet/Makefile.am
@@ -19,6 +19,9 @@ AM_CPPFLAGS = -DMATELOCALEDIR=\""$(datadir)/locale/"\" \
 	$(LIBNOTIFY_CFLAGS) \
 	$(WARN_CFLAGS)
 
+mate_sensors_applet_libdir= $(pkglibdir)
+mate_sensors_applet_lib_LTLIBRARIES=libmate_sensors_applet.la
+
 
 LIBS = $(GLIB_LIBS) $(GTK_LIBS) $(MATE_LIBS) $(CAIRO_LIBS) $(LIBNOTIFY_LIBS)
 
@@ -29,8 +32,23 @@ else
 libnotify_SRC =
 endif
 
-libexec_PROGRAMS = mate-sensors-applet
-mate_sensors_applet_SOURCES = main.c \
+libmate_sensors_applet_la_CFLAGS = \
+	$(MATE_APPLETS4_CFLAGS)		\
+	$(WARN_CFLAGS) \
+	$(AM_CFLAGS) \
+	$(NULL)
+
+libmate_sensors_applet_la_LDFLAGS = \
+	-module -avoid-version \
+	$(WARN_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+libmate_sensors_applet_la_LIBADD = \
+	$(MATE_APPLETS4_LIBS)		\
+	$(NULL)
+
+libmate_sensors_applet_la_SOURCES = main.c \
 		about-dialog.c \
 		about-dialog.h \
 		active-sensor.c \
@@ -47,8 +65,6 @@ mate_sensors_applet_SOURCES = main.c \
 		sensors-applet-settings.c \
 		sensors-applet-settings.h \
 		$(libnotify_SRC)
-
-mate_sensors_applet_LDADD = -ldl
 
 # install headers for plugins to use
 INST_H_FILES = sensors-applet-plugin.h sensors-applet-sensor.h

--- a/sensors-applet/main.c
+++ b/sensors-applet/main.c
@@ -42,7 +42,7 @@ static gboolean sensors_applet_fill(MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("SensorsAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("SensorsAppletFactory",
                                        PANEL_TYPE_APPLET,
                                        "SensorsApplet",
                                        sensors_applet_fill,


### PR DESCRIPTION
Wayland cannot use xembed/GtkPlug/GtkSocket so port to in-process. The applet then works on wayland. 