### PR TITLE
Allow building in or out of process

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,21 @@ SUBDIRS = sensors-applet lib plugins pixmaps po help
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-APPLET_LOCATION = $(libdir)/mate-sensors-applet/libmate_sensors_applet.so
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libdir)/mate-sensors-applet/libmate-sensors-applet.so
+else
+APPLET_LOCATION = $(libexecdir)/mate-sensors-applet
+
+servicedir = $(datadir)/dbus-1/services
+service_in_files = org.mate.panel.applet.SensorsAppletFactory.service.in
+service_DATA = $(service_in_files:.service.in=.service)
+
+org.mate.panel.applet.SensorsAppletFactory.service: $(service_in_files)
+	$(AM_V_GEN)sed \
+		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+		$< > $@
+
+endif
 
 appletdir =  $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in
@@ -11,6 +25,7 @@ applet_DATA = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
@@ -29,6 +44,7 @@ gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)
 
 CLEANFILES = $(applet_DATA) \
 	$(applet_in_files) \
+	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 
@@ -38,6 +54,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 
 EXTRA_DIST = $(ui_DATA) \
 	$(applet_in_files).in \
+	$(service_in_files) \
 	$(gsettingsschema_in_files) \
 	autogen.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,28 @@ GLIB_GSETTINGS
 PLUGIN_LIBTOOL_FLAGS="-module -avoid-version"
 AC_SUBST(PLUGIN_LIBTOOL_FLAGS)
 
+# ==========Whether to build in-process or out ========= #
+AC_ARG_ENABLE([in-process],
+              [AS_HELP_STRING([--enable-in-process],
+                              [Build all applet in-process])],
+              [enable_in_process=$enableval],
+              [enable_in_process=no])
+
+# Automake conditional on whether to build in-process
+AM_CONDITIONAL([ENABLE_IN_PROCESS], [test "x$enable_in_process" = "xyes"])
+# Automake value expected to be substitued in .mate-panel-apple.* for the value of "InProcess"
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_SUBST([APPLET_IN_PROCESS], [true])],
+      [AC_SUBST([APPLET_IN_PROCESS], [false])])
+# C conditional on whether to build in-process
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_DEFINE([ENABLE_IN_PROCESS], [1], [building in-process])])
+# Convenience C define selecting the right applet factory
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [factory=MATE_PANEL_APPLET_IN_PROCESS_FACTORY],
+      [factory=MATE_PANEL_APPLET_OUT_PROCESS_FACTORY])
+AC_DEFINE_UNQUOTED([PANEL_APPLET_FACTORY], [$factory], [Panel applet factory])
+
 # ================= generate files =================== #
 AC_CONFIG_FILES([
 	Makefile
@@ -286,4 +308,5 @@ echo "
        compiler:             ${CC}
        cflags:               ${CFLAGS}
        warning flags:        ${WARN_CFLAGS}
+       Build in-process:     $enable_in_process
 "

--- a/org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in.in
+++ b/org.mate.applets.SensorsApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=SensorsAppletFactory
-InProcess=true
 Location=@APPLET_LOCATION@
+InProcess=@APPLET_IN_PROCESS@
 Name=Sensors Applet Factory
 Description=Sensors Applet Factory
 

--- a/org.mate.panel.applet.SensorsAppletFactory.service.in
+++ b/org.mate.panel.applet.SensorsAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.SensorsAppletFactory
+Exec=@LIBEXECDIR@/mate-sensors-applet

--- a/sensors-applet/Makefile.am
+++ b/sensors-applet/Makefile.am
@@ -20,8 +20,6 @@ AM_CPPFLAGS = -DMATELOCALEDIR=\""$(datadir)/locale/"\" \
 	$(WARN_CFLAGS)
 
 mate_sensors_applet_libdir= $(pkglibdir)
-mate_sensors_applet_lib_LTLIBRARIES=libmate_sensors_applet.la
-
 
 LIBS = $(GLIB_LIBS) $(GTK_LIBS) $(MATE_LIBS) $(CAIRO_LIBS) $(LIBNOTIFY_LIBS)
 
@@ -32,6 +30,8 @@ else
 libnotify_SRC =
 endif
 
+if ENABLE_IN_PROCESS
+mate_sensors_applet_lib_LTLIBRARIES=libmate-sensors-applet.la
 libmate_sensors_applet_la_CFLAGS = \
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(WARN_CFLAGS) \
@@ -65,6 +65,26 @@ libmate_sensors_applet_la_SOURCES = main.c \
 		sensors-applet-settings.c \
 		sensors-applet-settings.h \
 		$(libnotify_SRC)
+else
+libexec_PROGRAMS = mate-sensors-applet
+mate_sensors_applet_SOURCES = main.c \
+		about-dialog.c \
+		about-dialog.h \
+		active-sensor.c \
+		active-sensor.h \
+		prefs-dialog.c \
+		prefs-dialog.h \
+		sensor-config-dialog.c \
+		sensor-config-dialog.h \
+		sensors-applet.c \
+		sensors-applet.h \
+		sensors-applet-sensor.h \
+		sensors-applet-plugins.c \
+		sensors-applet-plugins.h \
+		sensors-applet-settings.c \
+		sensors-applet-settings.h \
+		$(libnotify_SRC)
+endif
 
 # install headers for plugins to use
 INST_H_FILES = sensors-applet-plugin.h sensors-applet-sensor.h

--- a/sensors-applet/main.c
+++ b/sensors-applet/main.c
@@ -42,8 +42,8 @@ static gboolean sensors_applet_fill(MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("SensorsAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "SensorsApplet",
-                                       sensors_applet_fill,
-                                       NULL);
+PANEL_APPLET_FACTORY ("SensorsAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "SensorsApplet",
+                      sensors_applet_fill,
+                      NULL);


### PR DESCRIPTION
We need to build in-process if wayland is to be used, but allowing out of process builds allows distros to ship the same code as before if not supporting wayland. Note that if a buggy sensor crashes the applet, an out of process applet won't take down the whole panel.